### PR TITLE
Customising content negotiation using defaultMediaType and mediaType

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,14 +14,40 @@ function init (options) {
   var sendGraph = function (graph, mediaType) {
     var res = this
 
-    mediaType = res.req.accepts(mediaType)
+    // mediaType and defaultMediaType are interpreted as server preference about the
+    // representation format. They differ in the occasions when they can be set when
+    // implementing a server.
+    //
+    // mediaType can be set when calling sendGraph()
+    // defaultMediaType can be set when this body parser is attached to an express app
+    // mediaType overrides defaultMediaType
 
-    // express returns ['*/*'] if no match was found
-    if (Array.isArray(mediaType)) {
-      mediaType = undefined
+    // the list() method called below does not care about order when composing the list
+    var serializerListOrderedByPreference = options.formats.serializers.list()
+
+    if (!mediaType) {
+      mediaType = options.defaultMediaType
+    }
+    if (mediaType) {
+      // processing the server preference
+      if (!options.formats.serializers[mediaType]) {
+        // There is no serialiser for the server preference, ie. the server fails
+        res.status(500)
+
+        return Promise.promisify(res.end, {context: res})()
+      }
+
+      // req.accepts() requires a list of serialisers ordered by server preference,
+      // so to order the list according to our preference, we have to remove our
+      // preferred media type and re-add it at the first position
+      serializerListOrderedByPreference = [mediaType].concat(serializerListOrderedByPreference.filter(
+        function(mt) { return mt !== mediaType }))
     }
 
-    mediaType = mediaType || res.req.accepts(options.formats.serializers.list()) || options.defaultMediaType
+    // req.accepts() takes a list of media types ordered by server preference and does
+    // the content negotiation. Returns undefined if no agreement can be found between
+    // client and server preferences.
+    mediaType = res.req.accepts(serializerListOrderedByPreference)
 
     if (!mediaType || typeof mediaType !== 'string') {
       return Promise.reject(new httpErrors.NotAcceptable('no serializer found'))


### PR DESCRIPTION
Hi,

My aim was to set `text/turtle` as default media type for serialisation. Without my patch, the default was the first from the serialiser list in alphabetical order, so JSON-LD. Now I can set the default using:
````js
var express = require('express');
// Load RDF
var rdf = require('rdf-ext')
// Load the RDF parsers for HTTP messages
var rdfBodyParser = require('rdf-body-parser');

// The root app
app = express();
app.use(rdfBodyParser({'defaultMediaType' : 'text/turtle'});
````
Moreover, one can override the default for one `sendGraph` call using the second parameter in `sendGraph(graph, mediaType)`.

Cheers,

Tobias